### PR TITLE
Feature#35 mypage edit

### DIFF
--- a/app/controllers/customer/customers/sessions_controller.rb
+++ b/app/controllers/customer/customers/sessions_controller.rb
@@ -24,4 +24,22 @@ class Customer::Customers::SessionsController < Devise::SessionsController
   # def configure_sign_in_params
   #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
   # end
+  
+  before_action :reject_user, only: [:create]
+  
+  
+  def reject_user
+    @user = User.find_by(email: params[:user][:email])
+    if @user
+      if (@user.valid_password?(params[:user][:password]) && (@user.active_for_authentication? == false))
+        flash[:notice] = "退会済みです。"
+        redirect_to new_user_session_path
+      end
+    else
+      flash[:notice] = "必須項目を入力してください。"
+    end
+  end
+  #参考URLhttps://qiita.com/yuto_1014/items/358d0a425193b12c969a
+  
+  
 end

--- a/app/controllers/customer/customers_controller.rb
+++ b/app/controllers/customer/customers_controller.rb
@@ -4,11 +4,11 @@ class Customer::CustomersController < ApplicationController
     @customer = current_user
   end
   
-  def deleted
+  def delete
     @customer = current_user
   end
   
-  def delete
+  def deleted
     @customer = current_user
     @customer.update(is_deleted: true) #is_deletedをfalseからtrueへ変更し、論理削除
     reset_session #セッション情報のリセットする
@@ -16,7 +16,7 @@ class Customer::CustomersController < ApplicationController
   end
   
   def edit
-    @customer = cuurent_user
+    @user = current_user
   end
   
   def update
@@ -25,5 +25,12 @@ class Customer::CustomersController < ApplicationController
     flash[:notice] = 'You have updated customer successfully'
     redirect_to mypage_path
   end
-    
+  
+  
+  private
+  
+  def customer_path
+    params.require(:user).permit(:first_name, :family_name, :k_first_name, :k_family_name, :email, :address, :postal_code, :phone_number)
+  end
+  
 end

--- a/app/controllers/customer/customers_controller.rb
+++ b/app/controllers/customer/customers_controller.rb
@@ -12,6 +12,7 @@ class Customer::CustomersController < ApplicationController
     @customer = current_user
     @customer.update(is_deleted: true) #is_deletedをfalseからtrueへ変更し、論理削除
     reset_session #セッション情報のリセットする
+    flash[:notice] = "ありがとうございました。またのご利用を心よりお待ちしております。"
     redirect_to root_path
   end
   

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,5 +19,10 @@ class User < ApplicationRecord
   validates :phone_number,presence: true
 
   has_many :items, through: :cart_items
-
+  
+  def active_for_authentication?
+    super && (self.is_deleted == false)
+  end
+ #参考URLhttps://qiita.com/yuto_1014/items/358d0a425193b12c969a
+ 
 end

--- a/app/views/customer/customers/delete.html.erb
+++ b/app/views/customer/customers/delete.html.erb
@@ -1,0 +1,13 @@
+<div style="margin:10% 0;">
+  <h4 style="text-align:center">本当に退会しますか？</h3>
+
+  </br>
+
+  <P style="text-align:center">退会すると、会員登録情報や</br>これまでの購入履歴が閲覧できなくなります。</br>退会する場合は、「退会する」をクリックしてください</P>
+
+  <p style="text-align:center">
+    <%= link_to "退会しない", mypage_path, class: "btn btn-primary" %>
+    <%= link_to "退会する", deleted_path,method: :patch, class: "btn btn-danger" %>
+  </p>
+
+</div>

--- a/app/views/customer/customers/edit.html.erb
+++ b/app/views/customer/customers/edit.html.erb
@@ -1,0 +1,41 @@
+<div class='container'>
+  <div class='row'>
+    <div class="col-lg-6">
+
+      <h2>会員情報編集</h2>
+      
+      <%= form_with model:@user,url: customers_path,local:true do |f| %>
+      <div class="form-group">
+        <%= f.text_field :family_name, class:"form-control"%>
+      </div>
+      <div class="form-group">
+        <%= f.text_field :first_name, class:"form-control"%>
+      </div>
+      <div class="form-group">
+        <%= f.text_field :k_family_name, class:"form-control"%>
+      </div>
+      <div class="form-group">
+        <%= f.text_field :k_first_name, class:"form-control"%>
+      </div>
+      <div class="form-group">
+        <%= f.text_field :postal_code, class:"form-control"%>
+      </div>
+      <div class="form-group">
+        <%= f.text_field :address, class:"form-control"%>
+      </div>
+      <div class="form-group">
+        <%= f.text_field :phone_number, class:"form-control"%>
+      </div>
+      <div class="form-group">
+        <%= f.text_field :email, class:"form-control"%>
+      </div>
+      
+      <%= f.submit "編集内容を保存",class:"btn btn-success" %>
+      <% end %>
+      
+      </br>
+      
+      <%= link_to "退会する", delete_path, class: "btn btn-danger" %>
+    </div>
+  </div>
+</div>

--- a/app/views/customer/customers/sessions/new.html.erb
+++ b/app/views/customer/customers/sessions/new.html.erb
@@ -1,3 +1,4 @@
+<%= flash[:notice] %>
 <h2>ログイン</h2>
 
 <%= form_with model: @user, url: user_session_path, local: true do |f| %>

--- a/app/views/customer/customers/show.html.erb
+++ b/app/views/customer/customers/show.html.erb
@@ -1,7 +1,7 @@
 <h3 style="margin:20px 0px 20px 200px;">マイページ</h3>
 <div class="container-fluid">
   <div class="row">
-    <h4 style="width: 120px; margin:0px 0px 0px 45px;">登録情報</h4><%= link_to "編集する", customers_path, class: "btn btn-success" %>
+    <h4 style="width: 120px; margin:0px 0px 0px 45px;">登録情報</h4><%= link_to "編集する", edit_customers_path, class: "btn btn-success" %>
   </div>
 <div>
   

--- a/app/views/customer/homes/top.html.erb
+++ b/app/views/customer/homes/top.html.erb
@@ -1,3 +1,4 @@
+<%= flash[:notice] %>
 <div class="container-fluid">
   <div class="row">
 


### PR DESCRIPTION
#36の退会ページも含んでいます
・会員編集ページを追加しました。
・退会ページを追加しました。
・topページにflash[:notice]を追記し、退会遷移後のメッセージを表示させました。
・userモデルに、is_deletedカラムの真偽を判定するメソッドを定義しました。
・sessions_controllerに、退会後、同一email・パスワードでログインできないようにbefore_actionを追記しました。
・ログインページ(new.html.erb)に、flash[:notice]を追記し、退会者のemail,、パスワードが入力された際、退会済みが表示されるようにしました