### PR TITLE
[Add]顧客側　注文詳細ページ作成

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -61,3 +61,15 @@ footer {
 .nav-item {
   font-family:Droid Sans;
 }
+
+.index-item {
+  display: flex;
+}
+
+.container-item {
+  display: flex;
+}
+
+.form-group-mypage{
+  margin-bottom: 1rem;
+}

--- a/app/controllers/customer/orders_controller.rb
+++ b/app/controllers/customer/orders_controller.rb
@@ -14,11 +14,12 @@ class Customer::OrdersController < ApplicationController
         @cart_items.each do |cart_item|
         @order_items = @order.order_items.new
         @order_items.item_id = cart_item.item.id
-        @order_items.taxed_price = cart_item.item.price
+        @order_items.taxed_price = cart_item.item.price*1.1
         @order_items.piece = cart_item.piece
         @order_items.save
         @cart_items.destroy_all
       end
+      
 
       redirect_to thanks_path
     else
@@ -52,9 +53,11 @@ class Customer::OrdersController < ApplicationController
   end
 
   def index
+    @orders = Order.where(user: current_user)
   end
 
   def show
+    @order = Order.find(params[:id])
   end
 
   private

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -2,5 +2,7 @@ class Order < ApplicationRecord
   belongs_to :user
   has_many :items, through: :order_items
   has_many :order_items
-
+  
+   enum status: { "入金待ち": 0, "入金確認": 1, "制作中": 2, "発送準備中":3, "発送済み":4 }
+   enum payment_method: { "クレジットカード":0, "銀行振込":1 }
 end

--- a/app/views/customer/customers/edit.html.erb
+++ b/app/views/customer/customers/edit.html.erb
@@ -10,12 +10,12 @@
   <div class='row'>
     <div class="col-lg-2">氏名</div>
     <div class="col-lg-2">
-      <div class="form-group">
+      <div class="form-group-mypage">
         <%= f.text_field :family_name, class:"form-control"%>
       </div>
     </div>
     <div class="col-lg-2">
-      <div class="form-group">
+      <div class="form-group-mypage">
         <%= f.text_field :first_name, class:"form-control"%>
       </div>
     </div>
@@ -23,12 +23,12 @@
   <div class="row">
     <div class="col-lg-2">フリガナ</div>
     <div class="col-lg-2">
-      <div class="form-group">
+      <div class="form-group-mypage">
         <%= f.text_field :k_family_name, class:"form-control"%>
       </div>
     </div>
     <div class="col-lg-2">
-      <div class="form-group">
+      <div class="form-group-mypage">
         <%= f.text_field :k_first_name, class:"form-control"%>
       </div>
     </div>
@@ -36,7 +36,7 @@
   <div class="row">
     <div class="col-lg-2">郵便番号</div>
     <div class="col-lg-2">
-      <div class="form-group">
+      <div class="form-group-mypage">
         <%= f.text_field :postal_code, class:"form-control"%>
       </div>
     </div>
@@ -44,23 +44,23 @@
   <div class="row">
     <div class="col-lg-2">住所</div>
     <div class="col-lg-6">
-      <div class="form-group">
+      <div class="form-group-mypage">
         <%= f.text_field :address, class:"form-control"%>
       </div>
     </div>
   </div>
   <div class="row">
     <div class="col-lg-2">電話番号</div>
-    <div class="col-lg-2">
-      <div class="form-group">
+    <div class="col-lg-4">
+      <div class="form-group-mypage">
         <%= f.text_field :phone_number, class:"form-control"%>
       </div>
     </div>
   </div>
   <div class="row">
     <div class="col-lg-2">メールアドレス</div>
-    <div class="col-lg-2">
-      <div class="form-group">
+    <div class="col-lg-4">
+      <div class="form-group-mypage">
         <%= f.text_field :email, class:"form-control"%>
       </div>
     </div>
@@ -76,3 +76,4 @@
     </div>
   </div>
 </div>
+

--- a/app/views/customer/orders/index.html.erb
+++ b/app/views/customer/orders/index.html.erb
@@ -1,0 +1,41 @@
+<div class="container">
+　<div class="row" style="margin:30px 50px 40px 20px">
+    <div class="col-lg-4">
+      <h3 style="background-color: #DCDCDC;vertical-align: middle;text-align: center;">注文履歴一覧</h>
+    </div>
+  </div>
+
+  <div class="row" style="margin:30px 50px 40px 20px">
+      <div class="col-lg-12">
+        <table class="table">
+          <thead class="thead-light">
+            <tr>
+              <th>注文日</th>
+              <th>配送先</th>
+              <th>注文商品</th>
+              <th>支払金額</th>
+              <th>ステータス</th>
+              <th>注文詳細</th>
+            </tr>
+          </thead>
+
+          <tbody>
+            <% @orders.each do|order| %>
+              <tr>
+                <td><%= order.created_at.strftime('%Y/%m/%d') %></td>
+                <td><%= order.address %></td>
+                <% order.order_items.each do |order_item| %></td>
+                  <td>
+                    <%= order_item.item.name %>
+                  </td>
+                <% end %>
+                <td><%= "#{order.order_amount.to_s(:delimited)}円" %></td>
+                <td><%= order.status %></td>
+                <td><%= link_to "表示する", order_path(order.id), class: "btn btn-primary" %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+</div>

--- a/app/views/customer/orders/show.html.erb
+++ b/app/views/customer/orders/show.html.erb
@@ -1,0 +1,85 @@
+<div class="container">
+  <div class="row" style="margin:30px 50px 40px 20px">
+    <div class="col-lg-4 offset-lg-1">
+      <h3 style="background-color: #DCDCDC;vertical-align: middle;text-align: center;">注文履歴詳細</h>
+    </div>
+  </div>
+
+  <div class="row" >
+    <div class="col-lg-7">
+      <p>注文情報</p>
+      <table class="table">
+        <tr>
+          <th style="background-color: #DCDCDC;width:150px;">注文日</th>
+          <th><%= @order.created_at.strftime('%Y/%m/%d')%></th>
+        </tr>
+        <tr>
+          <th style="background-color: #DCDCDC">配送先</th>
+          <th><%= "#{@order.postal_code}" %> <br> <%= "#{@order.address}" %> <br> <%= "#{@order.user.family_name}#{@order.user.first_name}" %></th>
+        </tr>
+        <tr>
+          <th style="background-color: #DCDCDC">支払方法</th>
+          <th><%= @order.payment_method %></th>
+        </tr>
+        <tr>
+          <th style="background-color: #DCDCDC">ステータス</th>
+          <th><%= @order.status %></th>
+        </tr>
+      </table>
+    </div>
+    <div class="col-lg-3">
+      <p> 請求情報 </p>
+      <table class="table">
+        <tr>
+          <th style="background-color: #DCDCDC">商品合計</th>
+          <th>
+            <% @sum = 0%>
+            <% @order.order_items.each do |order_item| %>
+            <% @sum += (order_item.item.price*1.1*order_item.piece).round %>
+            <% end %>
+            <%= "#{@sum.to_s(:delimited)}円" %>
+          </th>
+        </tr>
+        <tr>
+          <th style="background-color: #DCDCDC">配送料</th>
+          <th><%= "#{@order.postage}円" %></th>
+        </tr>
+        <tr>
+          <th style="background-color: #DCDCDC">ご請求額</th>
+          <th><%= "#{@order.order_amount.to_s(:delimited)}円" %></th>
+        </tr>
+      </table>
+    </div>
+  </div>
+  <div class="row">
+    <p>注文内容</p>
+    <table class="table">
+      <thead class="thead-light">
+        <tr>
+          <th>商品</th>
+          <th>単価（税込）</th>
+          <th>個数</th>
+          <th>小計</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @order.order_items.each do |order_item| %>
+          <tr>
+            <th>
+              <%= order_item.item.name %>
+            </th>
+            <th>
+              <%= order_item.taxed_price.round.to_s(:delimited) %>
+            </th>
+            <th>
+              <%= order_item.piece %>
+            </th>
+            <th>
+              <%= (order_item.taxed_price*order_item.piece).round.to_s(:delimited)%>
+            </th>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>


### PR DESCRIPTION
・会員側　注文詳細ページを作成しました
・orderモデルにenum（支払方法）を追記しました
・orderコントロール内のクリエイトアクションの記述を変更しました
（前）@order_items.taxed_price = cart_item.item.price
（後）@order_items.taxed_price = cart_item.item.price*1.1
    ※前者だとorder_itemのtaxed_price（税込）のカラムに、itemのprice(税抜）が代入されてしまう為。
・顧客側　登録情報編集ページのクラス名、CSSを少し変更しました
・顧客側　注文一覧ページのレイアウトを少し変更しました