### PR TITLE
[Fix]退会ボタン押下後確認フォーム表示＃36

### DIFF
--- a/app/views/customer/customers/delete.html.erb
+++ b/app/views/customer/customers/delete.html.erb
@@ -7,7 +7,6 @@
 
   <p style="text-align:center">
     <%= link_to "退会しない", mypage_path, class: "btn btn-primary" %>
-    <%= link_to "退会する", deleted_path,method: :patch, class: "btn btn-danger" %>
+    <%= link_to "退会する", deleted_path,method: :patch,"data-confirm" => "退会手続きを行います", class: "btn btn-danger" %>
   </p>
-
 </div>


### PR DESCRIPTION
・退会ボタン押下後、最終確認のフォームを表示するようにしました
・現状、マイページ　編集ボタン押下　→ 登録情報編集画面 退会ボタン押下　→ 　退会ページ　退会ボタン押下　で退会になるので、最後にさらに確認フォームがでてきたらややくどくなります